### PR TITLE
Feature/error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maap_algorithms_jupyter_extension",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "A JupyterLab extension for managing algorithms on the MAAP",
   "keywords": [
     "algorithm",

--- a/src/components/RegistrationForm.tsx
+++ b/src/components/RegistrationForm.tsx
@@ -26,10 +26,11 @@ export const RegistrationForm = ({ data }) => {
     const [show, setShow] = useState(false);
     const [showSpinner, setShowSpinner] = useState(false)
     const [showNotification, setShowNotification] = useState(false);
+    const [algRegistrationSuccessful, setAlgRegistrationSuccessful] = useState(false);
 
     // Redux
     const dispatch = useDispatch()
-    const { registrationUrl, repoRunCommand, algoResource, algoContainer } = useSelector(selectAlgorithm)
+    const { registrationUrl, algorithmRegistrationError, repoRunCommand, algoResource, algoContainer } = useSelector(selectAlgorithm)
     const { setAlgoDesc,
             setAlgoDiskSpace,
             setAlgoName,
@@ -96,10 +97,16 @@ export const RegistrationForm = ({ data }) => {
         e.preventDefault()
         // setShowSpinner(true)
         let res = await registerAlgorithm()
+        console.log("graceal1 res which is returned by registering the alg is ");
+        console.log(res);
         if (res) {
             // setShowSpinner(false)
+            setAlgRegistrationSuccessful(true)
             handleModalShow()
             setShowNotification(true)
+        } else {
+            setAlgRegistrationSuccessful(false)
+            handleModalShow()
         }
     }
 
@@ -240,10 +247,19 @@ export const RegistrationForm = ({ data }) => {
         <div>
         {/* {showSpinner ? <Spinner animation="border" variant="primary" /> : */}
         <Modal show={show} aria-labelledby="contained-modal-title-vcenter" onHide={handleModalClose}>
-            <Modal.Header closeButton>
-                <Modal.Title>Algorithm submitted for registration</Modal.Title>
-            </Modal.Header>
-            <Modal.Body>Your algorithm was submitted for registration. You can view the progress here: <a href={registrationUrl} target="_blank">{registrationUrl}</a></Modal.Body>
+            {algRegistrationSuccessful ? 
+                <div>
+                    <Modal.Header closeButton>
+                        <Modal.Title>Algorithm submitted for registration</Modal.Title>
+                    </Modal.Header>
+                    <Modal.Body>Your algorithm was submitted for registration. You can view the progress here: <a href={registrationUrl} target="_blank">{registrationUrl}</a></Modal.Body>
+                </div>:
+                <div>
+                    <Modal.Header closeButton>
+                        <Modal.Title>Algorithm failed to submit for registration</Modal.Title>
+                    </Modal.Header>
+                    <Modal.Body>Error Message: {algorithmRegistrationError}</Modal.Body>
+                </div>}
             <Modal.Footer>
                 <Button variant="primary" onClick={handleModalClose}>
                     Close

--- a/src/components/RegistrationForm.tsx
+++ b/src/components/RegistrationForm.tsx
@@ -26,13 +26,11 @@ export const RegistrationForm = ({ data }) => {
     const [show, setShow] = useState(false);
     const [showSpinner, setShowSpinner] = useState(false)
     const [showNotification, setShowNotification] = useState(false);
-    const [algRegistrationSuccessful2, setAlgRegistrationSuccessful] = useState(false);
-    const algRegistrationSuccessful = true;
-    let registrationUrl = "https://repo.maap-project.org/root/register-job-hysds-v4/-/jobs/9661"
+    const [algRegistrationSuccessful, setAlgRegistrationSuccessful] = useState(false);
 
     // Redux
     const dispatch = useDispatch()
-    const { /*registrationUrl,*/ algorithmRegistrationError, repoRunCommand, algoResource, algoContainer } = useSelector(selectAlgorithm)
+    const { registrationUrl, algorithmRegistrationError, repoRunCommand, algoResource, algoContainer } = useSelector(selectAlgorithm)
     const { setAlgoDesc,
             setAlgoDiskSpace,
             setAlgoName,
@@ -254,7 +252,7 @@ export const RegistrationForm = ({ data }) => {
                     <Modal.Header closeButton>
                         <Modal.Title>Algorithm submitted for registration</Modal.Title>
                     </Modal.Header>
-                    <Modal.Body>Your algorithm was submitted for registration. You can view the progress here: <a href={registrationUrl} target="_blank">{registrationUrl}</a>. A yml file with this algorithm was added to your home directory (~).</Modal.Body>
+                    <Modal.Body>Your algorithm was submitted for registration. You can view the progress here: <a href={registrationUrl} target="_blank">{registrationUrl}</a></Modal.Body>
                 </div>:
                 <div>
                     <Modal.Header closeButton>

--- a/src/components/RegistrationForm.tsx
+++ b/src/components/RegistrationForm.tsx
@@ -26,11 +26,13 @@ export const RegistrationForm = ({ data }) => {
     const [show, setShow] = useState(false);
     const [showSpinner, setShowSpinner] = useState(false)
     const [showNotification, setShowNotification] = useState(false);
-    const [algRegistrationSuccessful, setAlgRegistrationSuccessful] = useState(false);
+    const [algRegistrationSuccessful2, setAlgRegistrationSuccessful] = useState(false);
+    const algRegistrationSuccessful = true;
+    let registrationUrl = "https://repo.maap-project.org/root/register-job-hysds-v4/-/jobs/9661"
 
     // Redux
     const dispatch = useDispatch()
-    const { registrationUrl, algorithmRegistrationError, repoRunCommand, algoResource, algoContainer } = useSelector(selectAlgorithm)
+    const { /*registrationUrl,*/ algorithmRegistrationError, repoRunCommand, algoResource, algoContainer } = useSelector(selectAlgorithm)
     const { setAlgoDesc,
             setAlgoDiskSpace,
             setAlgoName,
@@ -252,7 +254,7 @@ export const RegistrationForm = ({ data }) => {
                     <Modal.Header closeButton>
                         <Modal.Title>Algorithm submitted for registration</Modal.Title>
                     </Modal.Header>
-                    <Modal.Body>Your algorithm was submitted for registration. You can view the progress here: <a href={registrationUrl} target="_blank">{registrationUrl}</a></Modal.Body>
+                    <Modal.Body>Your algorithm was submitted for registration. You can view the progress here: <a href={registrationUrl} target="_blank">{registrationUrl}</a>. A yml file with this algorithm was added to your home directory (~).</Modal.Body>
                 </div>:
                 <div>
                     <Modal.Header closeButton>

--- a/src/components/RegistrationForm.tsx
+++ b/src/components/RegistrationForm.tsx
@@ -97,17 +97,14 @@ export const RegistrationForm = ({ data }) => {
         e.preventDefault()
         // setShowSpinner(true)
         let res = await registerAlgorithm()
-        console.log("graceal1 res which is returned by registering the alg is ");
-        console.log(res);
         if (res) {
             // setShowSpinner(false)
             setAlgRegistrationSuccessful(true)
-            handleModalShow()
             setShowNotification(true)
         } else {
             setAlgRegistrationSuccessful(false)
-            handleModalShow()
         }
+        handleModalShow()
     }
 
     useEffect(() => {

--- a/src/redux/slices/algorithmSlice.ts
+++ b/src/redux/slices/algorithmSlice.ts
@@ -16,7 +16,8 @@ const initialState: IAlgorithmSlice = {
   algoResource: "",
   algoContainer: "",
   inputId: 0,
-  registrationUrl: ""
+  registrationUrl: "",
+  algorithmRegistrationError: ""
 }
 
 export const algorithmSlice = createSlice({
@@ -27,6 +28,10 @@ export const algorithmSlice = createSlice({
 
     setRegistrationUrl: (state, action): any => {
       state.registrationUrl = action.payload
+    },
+
+    setAlgorithmRegistrationError: (state, action): any => {
+      state.algorithmRegistrationError = action.payload
     },
 
     incrementInputId: (state): any => {

--- a/src/types/slices.ts
+++ b/src/types/slices.ts
@@ -20,7 +20,8 @@ export interface IAlgorithmSlice {
     algoResource: any,
     algoContainer: "",
     inputId: number,
-    registrationUrl: ""
+    registrationUrl: "",
+    algorithmRegistrationError: ""
   }
 
 export interface ISplitPaneSlice {

--- a/src/utils/algoConfig.ts
+++ b/src/utils/algoConfig.ts
@@ -36,6 +36,7 @@ export async function registerAlgorithm() {
     // Pass the algo config file
     let response = await registerUsingFile(data.algorithm_name + ".yml", algo_data)
 
+    if (!response) return false;
     console.log(response)
     // update state
     store.dispatch(algorithmSlice.actions.setRegistrationUrl(response))

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -2,7 +2,8 @@ import { PageConfig } from '@jupyterlab/coreutils';
 import { IAlgorithmData } from '../types/slices';
 import { registeredAlgorithmsActions } from '../redux/slices/registeredAlgorithms';
 import { store } from "../redux/store";
-import { parseAlgorithmData } from "./parsers" 
+import { parseAlgorithmData } from "./parsers";
+import { algorithmSlice } from "../redux/slices/algorithmSlice";
 
 
 // export const getAlgorithmMetadata = (body: any) => {
@@ -25,6 +26,7 @@ export async function registerUsingFile(fileName: string, algo_data: any) {
   if (response_file) {
     console.log("submitting register")
     const response_register = await register(response_file.file, null)
+    if (!response_register) return false;
     const d = JSON.parse(response_register.response)
     console.log(d)
     console.log(d.message.job_web_url)
@@ -102,6 +104,8 @@ export async function register(file: string, data: any) {
     } catch (error) {
       console.log("error in new register endpoint")
       console.log(error)
+      store.dispatch(algorithmSlice.actions.setAlgorithmRegistrationError(error.toString()))
+      return false;
     }
 
   } else {


### PR DESCRIPTION
Adds error handling to algorithm registration 

When algorithm fails:
<img width="497" alt="Screenshot 2024-08-05 at 3 49 11 PM" src="https://github.com/user-attachments/assets/bd8124b2-1955-4ac1-82bc-a7d904cc42d6">

When algorithm is successful:
<img width="498" alt="Screenshot 2024-08-05 at 3 50 23 PM" src="https://github.com/user-attachments/assets/61a70b33-68d5-408b-8da8-ef39521023df">


Can test with this image: 'mas.dit.maap-project.org/root/maap-workspaces/jupyterlab/python:alg-error-handling'