### PR TITLE
Feature/container url dropdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maap_algorithms_jupyter_extension",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "A JupyterLab extension for managing algorithms on the MAAP",
   "keywords": [
     "algorithm",

--- a/src/components/RegistrationForm.tsx
+++ b/src/components/RegistrationForm.tsx
@@ -86,8 +86,8 @@ export const RegistrationForm = ({ data }) => {
         dispatch(setAlgoResource(value))
     }
 
-    const handleContainerURLChange = e => {
-        dispatch(setAlgoContainerURL(e.target.value))
+    const handleContainerURLChange = value => {
+        dispatch(setAlgoContainerURL(value))
     }
 
     const handleModalClose = () => setShow(false);
@@ -108,12 +108,9 @@ export const RegistrationForm = ({ data }) => {
     }
 
     useEffect(() => {
-        console.log("graceal1 in the useeffect that is setting the algo container url");
         // The container from which the workspace is running will be the default container for algorithm registration.
         getWorkspaceContainersOrDefault(null, null, true).then((param) => {
-            console.log("graceal1 in the then of getting the workspace containers")
-            console.log(param);
-            if (param != null) { dispatch(setAlgoContainerURL(param)) }
+            if (param[0] != null) dispatch(setAlgoContainerURL(param[0]))
         })
     }, []);
 

--- a/src/components/RegistrationForm.tsx
+++ b/src/components/RegistrationForm.tsx
@@ -10,7 +10,7 @@ import { TableFileInputs } from './TableFileInputs';
 import { TablePositionalInputs } from './TablePositionalInputs';
 import { registerAlgorithm } from '../utils/algoConfig';
 import AsyncSelect from 'react-select/async';
-import { getResources, getWorkspaceContainers, getWorkspaceContainersOrDefault } from "../utils/api";
+import { getResources, getWorkspaceContainers, getWorkspaceContainerOptions } from "../utils/api";
 import { Spinner } from 'react-bootstrap';
 import { checkUrlExists } from '../utils/utils';
 import { Notification } from "@jupyterlab/apputils";
@@ -30,12 +30,13 @@ export const RegistrationForm = ({ data }) => {
 
     // Redux
     const dispatch = useDispatch()
-    const { registrationUrl, algoName, repoBranch, algorithmRegistrationError, algorithmYmlFilePath, repoRunCommand, algoResource, algoContainer } = useSelector(selectAlgorithm)
+    const { registrationUrl, algoName, repoBranch, algorithmRegistrationError, algorithmYmlFilePath, repoRunCommand, algoResource, algoContainer, algoContainerOptions } = useSelector(selectAlgorithm)
     const { setAlgoDesc,
             setAlgoDiskSpace,
             setAlgoName,
             setAlgoResource,
             setAlgoContainerURL,
+            setAlgoContainerOptions,
             setRepoBranch,
             setRepoRunCommand,
             setRepoBuildCommand,
@@ -109,8 +110,14 @@ export const RegistrationForm = ({ data }) => {
 
     useEffect(() => {
         // The container from which the workspace is running will be the default container for algorithm registration.
-        getWorkspaceContainersOrDefault(null, null, true).then((param) => {
-            if (param[0] != null) dispatch(setAlgoContainerURL(param[0]))
+        getWorkspaceContainerOptions().then((param) => {
+            // param is a list where the first item is the default container 
+            if (param != null) {
+                dispatch(setAlgoContainerURL(param[0]))
+                console.log("graceal1 about to set container options to ");
+                console.log(param);
+                dispatch(setAlgoContainerOptions(param))
+            } 
         })
     }, []);
 
@@ -221,14 +228,13 @@ export const RegistrationForm = ({ data }) => {
                         <tr>
                             <td>Container URL</td>
                             <td>
-                                <AsyncSelect
-                                    cacheOptions
-                                    defaultOptions
+                                <select
                                     value={algoContainer}
-                                    loadOptions={getWorkspaceContainers}
                                     onChange={handleContainerURLChange}
-                                    placeholder="Enter container URL"
                                 />
+                                {algoContainerOptions ? algoContainerOptions.forEach(algoContainerOption => {
+                                    return <option value={algoContainerOption}>{algoContainerOption}</option>
+                                }): null}
                             </td>
                         </tr>
                     </tbody>

--- a/src/components/RegistrationForm.tsx
+++ b/src/components/RegistrationForm.tsx
@@ -10,7 +10,7 @@ import { TableFileInputs } from './TableFileInputs';
 import { TablePositionalInputs } from './TablePositionalInputs';
 import { registerAlgorithm } from '../utils/algoConfig';
 import AsyncSelect from 'react-select/async';
-import { getResources, getWorkspaceContainer } from "../utils/api";
+import { getResources, getWorkspaceContainers, getWorkspaceContainersOrDefault } from "../utils/api";
 import { Spinner } from 'react-bootstrap';
 import { checkUrlExists } from '../utils/utils';
 import { Notification } from "@jupyterlab/apputils";
@@ -108,10 +108,12 @@ export const RegistrationForm = ({ data }) => {
     }
 
     useEffect(() => {
+        console.log("graceal1 in the useeffect that is setting the algo container url");
         // The container from which the workspace is running will be the default container for algorithm registration.
-        getWorkspaceContainer().then((param) => {
-            let container = param["DOCKERIMAGE_PATH"]
-            if (container != null) { dispatch(setAlgoContainerURL(container)) }
+        getWorkspaceContainersOrDefault(null, null, true).then((param) => {
+            console.log("graceal1 in the then of getting the workspace containers")
+            console.log(param);
+            if (param != null) { dispatch(setAlgoContainerURL(param)) }
         })
     }, []);
 
@@ -222,7 +224,14 @@ export const RegistrationForm = ({ data }) => {
                         <tr>
                             <td>Container URL</td>
                             <td>
-                                <Form.Control type="text" defaultValue={algoContainer} placeholder="Enter container URL" onChange={handleContainerURLChange} />
+                                <AsyncSelect
+                                    cacheOptions
+                                    defaultOptions
+                                    value={algoContainer}
+                                    loadOptions={getWorkspaceContainers}
+                                    onChange={handleContainerURLChange}
+                                    placeholder="Enter container URL"
+                                />
                             </td>
                         </tr>
                     </tbody>

--- a/src/components/RegistrationForm.tsx
+++ b/src/components/RegistrationForm.tsx
@@ -10,7 +10,7 @@ import { TableFileInputs } from './TableFileInputs';
 import { TablePositionalInputs } from './TablePositionalInputs';
 import { registerAlgorithm } from '../utils/algoConfig';
 import AsyncSelect from 'react-select/async';
-import { getResources, getWorkspaceContainers, getWorkspaceContainerOptions } from "../utils/api";
+import { getResources, getWorkspaceContainers } from "../utils/api";
 import { Spinner } from 'react-bootstrap';
 import { checkUrlExists } from '../utils/utils';
 import { Notification } from "@jupyterlab/apputils";
@@ -30,13 +30,12 @@ export const RegistrationForm = ({ data }) => {
 
     // Redux
     const dispatch = useDispatch()
-    const { registrationUrl, algoName, repoBranch, algorithmRegistrationError, algorithmYmlFilePath, repoRunCommand, algoResource, algoContainer, algoContainerOptions } = useSelector(selectAlgorithm)
+    const { registrationUrl, algoName, repoBranch, algorithmRegistrationError, algorithmYmlFilePath, repoRunCommand, algoResource, algoContainer } = useSelector(selectAlgorithm)
     const { setAlgoDesc,
             setAlgoDiskSpace,
             setAlgoName,
             setAlgoResource,
             setAlgoContainerURL,
-            setAlgoContainerOptions,
             setRepoBranch,
             setRepoRunCommand,
             setRepoBuildCommand,
@@ -107,19 +106,6 @@ export const RegistrationForm = ({ data }) => {
         }
         handleModalShow()
     }
-
-    useEffect(() => {
-        // The container from which the workspace is running will be the default container for algorithm registration.
-        getWorkspaceContainerOptions().then((param) => {
-            // param is a list where the first item is the default container 
-            if (param != null) {
-                dispatch(setAlgoContainerURL(param[0]))
-                console.log("graceal1 about to set container options to ");
-                console.log(param);
-                dispatch(setAlgoContainerOptions(param))
-            } 
-        })
-    }, []);
 
     useEffect(() => {
         if (showNotification) {
@@ -228,13 +214,13 @@ export const RegistrationForm = ({ data }) => {
                         <tr>
                             <td>Container URL</td>
                             <td>
-                                <select
-                                    value={algoContainer}
-                                    onChange={handleContainerURLChange}
-                                />
-                                {algoContainerOptions ? algoContainerOptions.forEach(algoContainerOption => {
-                                    return <option value={algoContainerOption}>{algoContainerOption}</option>
-                                }): null}
+                            <AsyncSelect
+                                cacheOptions
+                                defaultOptions
+                                value={algoContainer}
+                                loadOptions={getWorkspaceContainers}
+                                onChange={handleContainerURLChange}
+                            />
                             </td>
                         </tr>
                     </tbody>

--- a/src/redux/slices/algorithmSlice.ts
+++ b/src/redux/slices/algorithmSlice.ts
@@ -15,7 +15,6 @@ const initialState: IAlgorithmSlice = {
   algoDiskSpace: "",
   algoResource: "",
   algoContainer: "",
-  algoContainerOptions: "",
   inputId: 0,
   registrationUrl: "",
   algorithmRegistrationError: "",
@@ -78,12 +77,6 @@ export const algorithmSlice = createSlice({
 
     setAlgoContainerURL: (state, action): any => {
       state.algoContainer = action.payload
-    },
-
-    setAlgoContainerOptions: (state, action): any => {
-      console.log("graceal1 setting the algo container options");
-      console.log(action.payload);
-      state.algoContainerOptions = action.payload
     },
 
     addConfigData: (state, action): any => {

--- a/src/redux/slices/algorithmSlice.ts
+++ b/src/redux/slices/algorithmSlice.ts
@@ -15,6 +15,7 @@ const initialState: IAlgorithmSlice = {
   algoDiskSpace: "",
   algoResource: "",
   algoContainer: "",
+  algoContainerOptions: "",
   inputId: 0,
   registrationUrl: "",
   algorithmRegistrationError: "",
@@ -77,6 +78,12 @@ export const algorithmSlice = createSlice({
 
     setAlgoContainerURL: (state, action): any => {
       state.algoContainer = action.payload
+    },
+
+    setAlgoContainerOptions: (state, action): any => {
+      console.log("graceal1 setting the algo container options");
+      console.log(action.payload);
+      state.algoContainerOptions = action.payload
     },
 
     addConfigData: (state, action): any => {

--- a/src/types/slices.ts
+++ b/src/types/slices.ts
@@ -19,7 +19,6 @@ export interface IAlgorithmSlice {
     algoDiskSpace: "",
     algoResource: any,
     algoContainer: any,
-    algoContainerOptions: any,
     inputId: number,
     registrationUrl: "",
     algorithmRegistrationError: "",

--- a/src/types/slices.ts
+++ b/src/types/slices.ts
@@ -19,6 +19,7 @@ export interface IAlgorithmSlice {
     algoDiskSpace: "",
     algoResource: any,
     algoContainer: any,
+    algoContainerOptions: any,
     inputId: number,
     registrationUrl: "",
     algorithmRegistrationError: "",

--- a/src/types/slices.ts
+++ b/src/types/slices.ts
@@ -18,7 +18,7 @@ export interface IAlgorithmSlice {
     algoDesc: "",
     algoDiskSpace: "",
     algoResource: any,
-    algoContainer: "",
+    algoContainer: any,
     inputId: number,
     registrationUrl: "",
     algorithmRegistrationError: "",

--- a/src/utils/algoConfig.ts
+++ b/src/utils/algoConfig.ts
@@ -18,7 +18,7 @@ export async function registerAlgorithm() {
     data.algorithm_name = storeData.algoName
     data.algorithm_version = storeData.repoBranch
     data.disk_space = storeData.algoDiskSpace + "GB" // maap-py request expects units in value string
-    data.docker_container_url = storeData.algoContainer
+    data.docker_container_url = storeData.algoContainer.value
     data.repository_url = storeData.repoUrl
     data.run_command = storeData.repoRunCommand
     data.build_command = storeData.repoBuildCommand

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -264,8 +264,12 @@ export async function unregisterAlgorithm(algo_id: string) {
   return ""
 }
 
+export async function getWorkspaceContainers(inputValue, callback) {
+  return getWorkspaceContainersOrDefault(inputValue, callback, false)
+}
 
-export async function getWorkspaceContainer() {
+export async function getWorkspaceContainersOrDefault(inputValue = null, callback = null, getDefaultContainer = false) {
+  var workspaceContainers: any[] = []
   var requestUrl = new URL(PageConfig.getBaseUrl() + 'jupyter-server-extension/getWorkspaceContainer');
   console.log(requestUrl.href)
 
@@ -283,7 +287,28 @@ export async function getWorkspaceContainer() {
     console.log("resolved")
     const r_data = await response.json();
     console.log(r_data)
-    return r_data
+    if (getDefaultContainer) {
+      console.log("graceal1 returning the default conatiner as ")
+      console.log(r_data["DOCKERIMAGE_PATH_DEFAULT"])
+      return r_data["DOCKERIMAGE_PATH_DEFAULT"]
+    }
+    Object.entries(r_data).forEach(([key, value]) => {
+      let workspaceContainer: any = {}
+      workspaceContainer["value"] = value
+      workspaceContainer["label"] = value
+      workspaceContainers.push(workspaceContainer)
+    })
+    if (inputValue && callback) {
+      const filtered = filterOptions(workspaceContainers, inputValue);
+      console.log("graceal1 calling the callback with filtered");
+      console.log(filtered);
+      console.log(callback);
+      console.log(inputValue);
+      callback(filtered);
+    }
+    console.log("graceal1 returning workspace containers");
+    console.log(workspaceContainers);
+    return workspaceContainers
   } catch (error) {
     console.log("error in new endpoint")
     console.log(error)

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -265,10 +265,21 @@ export async function unregisterAlgorithm(algo_id: string) {
 }
 
 export async function getWorkspaceContainers(inputValue, callback) {
-  return getWorkspaceContainersOrDefault(inputValue, callback, false)
+  const containerOptions = store.getState().Algorithm.algoContainerOptions;
+  console.log("graceal1 container options from store are");
+  console.log(containerOptions);
+  console.log(store.getState());
+  const filtered = filterOptions(containerOptions, inputValue);
+  callback(filtered);
+  return containerOptions;
 }
 
-export async function getWorkspaceContainersOrDefault(inputValue = null, callback = null, getDefaultContainer = false) {
+/**
+ * 
+ * @returns Returns a list of the workspace containers with the first item 
+ * in the list being the default
+ */
+export async function getWorkspaceContainerOptions() {
   var workspaceContainers: any[] = []
   var requestUrl = new URL(PageConfig.getBaseUrl() + 'jupyter-server-extension/getWorkspaceContainer');
   console.log(requestUrl.href)
@@ -287,19 +298,19 @@ export async function getWorkspaceContainersOrDefault(inputValue = null, callbac
     console.log("resolved")
     const r_data = await response.json();
     console.log(r_data)
-    if (getDefaultContainer) {
-      return [{"value": r_data["DOCKERIMAGE_PATH_DEFAULT"], "label": r_data["DOCKERIMAGE_PATH_DEFAULT"]}]
-    }
+    let workspaceContainerDefault: any = {}
+    workspaceContainerDefault["value"] = r_data["DOCKERIMAGE_PATH_DEFAULT"]
+    workspaceContainerDefault["label"] = r_data["DOCKERIMAGE_PATH_DEFAULT"]
+    workspaceContainers.push(workspaceContainerDefault);
+
     Object.entries(r_data).forEach(([key, value]) => {
-      let workspaceContainer: any = {}
-      workspaceContainer["value"] = value
-      workspaceContainer["label"] = value
-      workspaceContainers.push(workspaceContainer)
+      if (value !== workspaceContainerDefault) {
+        let workspaceContainer: any = {}
+        workspaceContainer["value"] = value
+        workspaceContainer["label"] = value
+        workspaceContainers.push(workspaceContainer)
+      }
     })
-    if (inputValue && callback) {
-      const filtered = filterOptions(workspaceContainers, inputValue);
-      callback(filtered);
-    }
     return workspaceContainers
   } catch (error) {
     console.log("error in new endpoint")

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -288,9 +288,7 @@ export async function getWorkspaceContainersOrDefault(inputValue = null, callbac
     const r_data = await response.json();
     console.log(r_data)
     if (getDefaultContainer) {
-      console.log("graceal1 returning the default conatiner as ")
-      console.log(r_data["DOCKERIMAGE_PATH_DEFAULT"])
-      return r_data["DOCKERIMAGE_PATH_DEFAULT"]
+      return [{"value": r_data["DOCKERIMAGE_PATH_DEFAULT"], "label": r_data["DOCKERIMAGE_PATH_DEFAULT"]}]
     }
     Object.entries(r_data).forEach(([key, value]) => {
       let workspaceContainer: any = {}
@@ -300,14 +298,8 @@ export async function getWorkspaceContainersOrDefault(inputValue = null, callbac
     })
     if (inputValue && callback) {
       const filtered = filterOptions(workspaceContainers, inputValue);
-      console.log("graceal1 calling the callback with filtered");
-      console.log(filtered);
-      console.log(callback);
-      console.log(inputValue);
       callback(filtered);
     }
-    console.log("graceal1 returning workspace containers");
-    console.log(workspaceContainers);
     return workspaceContainers
   } catch (error) {
     console.log("error in new endpoint")

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -264,22 +264,12 @@ export async function unregisterAlgorithm(algo_id: string) {
   return ""
 }
 
-export async function getWorkspaceContainers(inputValue, callback) {
-  const containerOptions = store.getState().Algorithm.algoContainerOptions;
-  console.log("graceal1 container options from store are");
-  console.log(containerOptions);
-  console.log(store.getState());
-  const filtered = filterOptions(containerOptions, inputValue);
-  callback(filtered);
-  return containerOptions;
-}
-
 /**
  * 
  * @returns Returns a list of the workspace containers with the first item 
  * in the list being the default
  */
-export async function getWorkspaceContainerOptions() {
+export async function getWorkspaceContainers() {
   var workspaceContainers: any[] = []
   var requestUrl = new URL(PageConfig.getBaseUrl() + 'jupyter-server-extension/getWorkspaceContainer');
   console.log(requestUrl.href)
@@ -298,19 +288,15 @@ export async function getWorkspaceContainerOptions() {
     console.log("resolved")
     const r_data = await response.json();
     console.log(r_data)
-    let workspaceContainerDefault: any = {}
-    workspaceContainerDefault["value"] = r_data["DOCKERIMAGE_PATH_DEFAULT"]
-    workspaceContainerDefault["label"] = r_data["DOCKERIMAGE_PATH_DEFAULT"]
-    workspaceContainers.push(workspaceContainerDefault);
-
     Object.entries(r_data).forEach(([key, value]) => {
-      if (value !== workspaceContainerDefault) {
-        let workspaceContainer: any = {}
+      let workspaceContainer: any = {}
         workspaceContainer["value"] = value
         workspaceContainer["label"] = value
         workspaceContainers.push(workspaceContainer)
-      }
     })
+    // set the algorithm container url to the default
+    let defaultDockerImagePath = r_data["DOCKERIMAGE_PATH_DEFAULT"];
+    store.dispatch(algorithmSlice.actions.setAlgoContainerURL({"value": defaultDockerImagePath, "label": defaultDockerImagePath}))
     return workspaceContainers
   } catch (error) {
     console.log("error in new endpoint")

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -290,9 +290,9 @@ export async function getWorkspaceContainers() {
     console.log(r_data)
     Object.entries(r_data).forEach(([key, value]) => {
       let workspaceContainer: any = {}
-        workspaceContainer["value"] = value
-        workspaceContainer["label"] = value
-        workspaceContainers.push(workspaceContainer)
+      workspaceContainer["value"] = value
+      workspaceContainer["label"] = value
+      workspaceContainers.push(workspaceContainer)
     })
     // set the algorithm container url to the default
     let defaultDockerImagePath = r_data["DOCKERIMAGE_PATH_DEFAULT"];


### PR DESCRIPTION
Dropdown for the container url:
<img width="986" alt="Screenshot 2024-11-14 at 5 14 14 PM" src="https://github.com/user-attachments/assets/96d17f5a-f8b4-40f7-912f-61544732cc4e">

Where there is a default specified in the environment variables set from the devfile (default should normally be maap_base_image) 

Also needs this PR to jupyter server extension: https://github.com/MAAP-Project/jupyter-server-extension/pull/15

Which sets the naming convention to be 2 environment variables: DOCKERIMAGE_PATH_DEFAULT and DOCKERIMAGE_PATH_BASE_IMAGE 

If environment variables are not set, there are no options in the dropdown. @marjo-luc Do we want this to be the expected behavior? 
<img width="741" alt="Screenshot 2024-11-14 at 5 18 53 PM" src="https://github.com/user-attachments/assets/3d9bd946-b893-4cd9-8c8a-36391cc397d2">

Can test with this image: 'mas.dit.maap-project.org/root/maap-workspaces/jupyterlab/python:container-url-dropdown' 